### PR TITLE
[ADD] l10n_bg_hr_holidays: leave balance SQL view

### DIFF
--- a/l10n_bg_hr_holidays/__manifest__.py
+++ b/l10n_bg_hr_holidays/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Bulgaria - HR Holidays',
-    'version': '19.0.1.0.4',
+    'version': '19.0.1.1.0',
     'category': 'Human Resources/Time Off',
     'summary': 'Bulgarian localization for HR Holidays',
     'description': """
@@ -75,6 +75,7 @@ Full documentation available in the module's data folder:
         'views/hr_leave_views.xml',
         'views/hr_leave_type_views.xml',
         'views/l10n_bg_nssi_leave_reason.xml',
+        'views/hr_leave_balance_views.xml',
     ],
     'demo': [
     ],

--- a/l10n_bg_hr_holidays/models/__init__.py
+++ b/l10n_bg_hr_holidays/models/__init__.py
@@ -1,4 +1,5 @@
 from . import hr_leave
 from . import hr_leave_type
 from . import l10n_bg_nssi_leave_reason
+from . import hr_leave_balance
 

--- a/l10n_bg_hr_holidays/models/hr_leave_balance.py
+++ b/l10n_bg_hr_holidays/models/hr_leave_balance.py
@@ -1,0 +1,43 @@
+from odoo import fields, models, tools
+
+
+class HrLeaveBalance(models.Model):
+    _name = "hr.leave.balance"
+    _description = "Leave Balance"
+    _auto = False
+    _order = "employee_id, leave_type_id"
+
+    employee_id = fields.Many2one("hr.employee", string="Employee", readonly=True)
+    leave_type_id = fields.Many2one("hr.leave.type", string="Leave Type", readonly=True)
+    allocated_days = fields.Float(string="Allocated Days", readonly=True)
+    taken_days = fields.Float(string="Taken Days", readonly=True)
+    remaining_days = fields.Float(string="Remaining Days", readonly=True)
+
+    def init(self):
+        tools.drop_view_if_exists(self.env.cr, self._table)
+        self.env.cr.execute("""
+            CREATE OR REPLACE VIEW %s AS (
+                SELECT
+                    ROW_NUMBER() OVER (ORDER BY a.employee_id, a.holiday_status_id) AS id,
+                    a.employee_id AS employee_id,
+                    a.holiday_status_id AS leave_type_id,
+                    SUM(a.number_of_days) AS allocated_days,
+                    COALESCE((
+                        SELECT SUM(l.number_of_days)
+                        FROM hr_leave l
+                        WHERE l.employee_id = a.employee_id
+                          AND l.holiday_status_id = a.holiday_status_id
+                          AND l.state = 'validate'
+                    ), 0) AS taken_days,
+                    SUM(a.number_of_days) - COALESCE((
+                        SELECT SUM(l.number_of_days)
+                        FROM hr_leave l
+                        WHERE l.employee_id = a.employee_id
+                          AND l.holiday_status_id = a.holiday_status_id
+                          AND l.state = 'validate'
+                    ), 0) AS remaining_days
+                FROM hr_leave_allocation a
+                WHERE a.state = 'validate'
+                GROUP BY a.employee_id, a.holiday_status_id
+            )
+        """ % self._table)

--- a/l10n_bg_hr_holidays/security/ir.model.access.csv
+++ b/l10n_bg_hr_holidays/security/ir.model.access.csv
@@ -1,3 +1,5 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_nssi_leave_reason_user,NSSI leave reason - read,model_nssi_leave_reason,base.group_user,1,0,0,0
 access_nssi_leave_reason_hr_manager,NSSI leave reason - full,model_nssi_leave_reason,hr_holidays.group_hr_holidays_manager,1,1,1,1
+access_hr_leave_balance_user,hr.leave.balance user,model_hr_leave_balance,base.group_user,1,0,0,0
+access_hr_leave_balance_manager,hr.leave.balance manager,model_hr_leave_balance,hr_holidays.group_hr_holidays_manager,1,0,0,0

--- a/l10n_bg_hr_holidays/views/hr_leave_balance_views.xml
+++ b/l10n_bg_hr_holidays/views/hr_leave_balance_views.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_hr_leave_balance_list" model="ir.ui.view">
+        <field name="name">hr.leave.balance.list</field>
+        <field name="model">hr.leave.balance</field>
+        <field name="arch" type="xml">
+            <list string="Leave Balance" create="0" edit="0" delete="0">
+                <field name="employee_id"/>
+                <field name="leave_type_id"/>
+                <field name="allocated_days" sum="Total"/>
+                <field name="taken_days" sum="Total"/>
+                <field name="remaining_days" sum="Total" decoration-danger="remaining_days &lt; 0"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="view_hr_leave_balance_search" model="ir.ui.view">
+        <field name="name">hr.leave.balance.search</field>
+        <field name="model">hr.leave.balance</field>
+        <field name="arch" type="xml">
+            <search string="Search Leave Balance">
+                <field name="employee_id"/>
+                <field name="leave_type_id"/>
+                <group>
+                    <filter string="Employee" name="group_employee" context="{&apos;group_by&apos;: &apos;employee_id&apos;}"/>
+                    <filter string="Leave Type" name="group_leave_type" context="{&apos;group_by&apos;: &apos;leave_type_id&apos;}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <record id="action_hr_leave_balance" model="ir.actions.act_window">
+        <field name="name">Leave Balance</field>
+        <field name="res_model">hr.leave.balance</field>
+        <field name="view_mode">list</field>
+        <field name="search_view_id" ref="view_hr_leave_balance_search"/>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                No leave allocations found
+            </p>
+        </field>
+    </record>
+
+    <menuitem id="menu_hr_leave_balance"
+              name="Leave Balance"
+              parent="hr_holidays.menu_hr_holidays_management"
+              action="action_hr_leave_balance"
+              sequence="5"/>
+
+</odoo>


### PR DESCRIPTION
Add hr.leave.balance model (_auto=False) with a PostgreSQL view that aggregates validated allocations and leaves per employee per leave type, exposing allocated, taken and remaining days.

Includes list view, search view, action and menu entry under Time Off > Management > Leave Balance.

Replaces manual x_leave_balance workaround previously created in DB.