### PR TITLE
[IMP] l10n_bg_hr: open hr.version form from History list

### DIFF
--- a/l10n_bg_hr/models/hr_version.py
+++ b/l10n_bg_hr/models/hr_version.py
@@ -240,3 +240,13 @@ class HrVersion(models.Model):
                 if next_no:
                     vals['l10n_bg_contract_number'] = next_no
         return super().create(vals_list)
+
+    def action_open_version(self):
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'hr.version',
+            'res_id': self.id,
+            'views': [(False, 'form')],
+            'target': 'current',
+        }


### PR DESCRIPTION
Override action_open_version to open hr.version in its own form view instead of redirecting to hr.employee. This allows Print menu to show reports bound to hr.version (employment contracts, amendments, etc.) when navigating from the employee History tab.